### PR TITLE
Changed Peer and Message back to interfaces.

### DIFF
--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/Message.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/Message.java
@@ -2,19 +2,19 @@ package ingsw.group1.msglibrary;
 
 /**
  * @author Riccardo De Zen based on decisions of whole class.
- * @param <D> The type of data this message contains.
  * @param <P> The type of {@code Peer} this message allows to communicate.
+ * @param <D> The type of data this message carries.
  */
-public interface Message<D, P extends Peer>{
-    /**
-     * @return the data in this message
-     */
-    D getData();
-
+public interface Message<P extends Peer, D>{
     /**
      * @return the peer for this message
      */
     P getPeer();
+
+    /**
+     * @return the data in this message
+     */
+    D getData();
 
     /**
      * Method to check whether this message is valid

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/Message.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/Message.java
@@ -1,37 +1,24 @@
 package ingsw.group1.msglibrary;
 
-import androidx.annotation.Nullable;
-
 /**
  * @author Riccardo De Zen based on decisions of whole class.
  * @param <D> The type of data this message contains.
  * @param <P> The type of {@code Peer} this message allows to communicate.
  */
-public abstract class Message<D, P extends Peer>{
+public interface Message<D, P extends Peer>{
     /**
      * @return the data in this message
      */
-    public abstract D getData();
+    D getData();
 
     /**
      * @return the peer for this message
      */
-    public abstract P getPeer();
+    P getPeer();
 
     /**
      * Method to check whether this message is valid
      * @return true if the message is valid, false if not
      */
-    public abstract boolean isValid();
-
-    /**
-     * By default a message, as defined here, does not equal another, because two messages with same
-     * Data and Peer can exist.
-     * @param obj
-     * @return
-     */
-    @Override
-    public boolean equals(@Nullable Object obj) {
-        return super.equals(obj);
-    }
+    boolean isValid();
 }

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/Peer.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/Peer.java
@@ -3,6 +3,7 @@ package ingsw.group1.msglibrary;
 /**
  * @author Riccardo De Zen. Based on suggestion from Dr. Li Dao Hong.
  * @param <T> The type of address that identifies the Peer.
+ * @param <P> The type of {@code Peer} the implementing class can compare itself to.
  */
 public interface Peer<T extends Comparable<T>, P extends Peer<T,P>> extends Comparable<P> {
     /**

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/Peer.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/Peer.java
@@ -1,45 +1,18 @@
 package ingsw.group1.msglibrary;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 /**
  * @author Riccardo De Zen. Based on suggestion from Dr. Li Dao Hong.
  * @param <T> The type of address that identifies the Peer.
  */
-public abstract class Peer<T extends Comparable<T>> implements Comparable<Peer<T>> {
+public interface Peer<T extends Comparable<T>, P extends Peer<T,P>> extends Comparable<P> {
     /**
      * @return the address of this Peer
      */
-    public abstract T getAddress();
+    T getAddress();
 
     /**
      * Method to check whether this Peer is valid
      * @return true if this Peer is valid, false if not
      */
-    public abstract boolean isValid();
-
-    /**
-     * Two Peers are considered equal by default if their addresses are equal.
-     *
-     * @param obj the other Peer
-     * @return true if the other Peer equals this, false if not.
-     */
-    @Override
-    public boolean equals(@Nullable Object obj) {
-        if (obj instanceof Peer) {
-            Peer other = (Peer) obj;
-            return other.getAddress().equals(this.getAddress());
-        } else return false;
-    }
-
-    /**
-     * Two Peers can, by default, be ordered using their address as a key.
-     * @param peer the Peer to compare
-     * @return the result of the comparison between the addresses
-     */
-    @Override
-    public int compareTo(@NonNull Peer<T> peer) {
-        return peer.getAddress().compareTo(this.getAddress());
-    }
+    boolean isValid();
 }

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/RandomPeerGenerator.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/RandomPeerGenerator.java
@@ -4,7 +4,7 @@ package ingsw.group1.msglibrary;
  * @author Riccardo De Zen.
  * @param <P> the type of generated Peer.
  */
-public interface RandomPeerGenerator<A extends Comparable<A>, P extends Peer<A>> {
+public interface RandomPeerGenerator<A extends Comparable<A>, P extends Peer<A,P>> {
     /**
      * @return a valid built Peer.
      */

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSMessage.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSMessage.java
@@ -16,7 +16,7 @@ import ingsw.group1.msglibrary.exceptions.InvalidMessageException;
  * @author Riccardo De Zen based on decisions of whole class.
  */
 @Entity(tableName = SMSMessage.SMS_TABLE_NAME)
-public class SMSMessage implements Message<String, SMSPeer>{
+public class SMSMessage implements Message<SMSPeer, String>{
 
     //Name of the Entity table inside the Database.
     public static final String SMS_TABLE_NAME = "smsmessage";

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSMessage.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSMessage.java
@@ -16,7 +16,7 @@ import ingsw.group1.msglibrary.exceptions.InvalidMessageException;
  * @author Riccardo De Zen based on decisions of whole class.
  */
 @Entity(tableName = SMSMessage.SMS_TABLE_NAME)
-public class SMSMessage extends Message<String, SMSPeer>{
+public class SMSMessage implements Message<String, SMSPeer>{
 
     //Name of the Entity table inside the Database.
     public static final String SMS_TABLE_NAME = "smsmessage";

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSPeer.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSPeer.java
@@ -12,7 +12,7 @@ import ingsw.group1.msglibrary.exceptions.InvalidAddressException;
 /**
  * @author Riccardo De Zen. Based on decisions of whole class.
  */
-public class SMSPeer extends Peer<String> {
+public class SMSPeer implements Peer<String, SMSPeer> {
     /**
      * Field representing an Invalid SMSPeer. To avoid propagation of Invalid Peers this should
      * not be used as a return statement outside mock tests.
@@ -103,10 +103,28 @@ public class SMSPeer extends Peer<String> {
         return address;
     }
 
+    /**
+     * Two Peers are considered equal by default if their addresses are equal.
+     *
+     * @param obj the other Peer
+     * @return true if the other Peer equals this, false if not.
+     */
     @Override
     public boolean equals(@Nullable Object obj) {
-        if (obj instanceof SMSPeer) return ((SMSPeer) obj).address.equals(this.address);
-        else return false;
+        if (obj instanceof Peer) {
+            Peer other = (Peer) obj;
+            return other.getAddress().equals(this.getAddress());
+        } else return false;
+    }
+
+    /**
+     * Two Peers can, by default, be ordered using their address as a key.
+     * @param peer the Peer to compare
+     * @return the result of the comparison between the addresses
+     */
+    @Override
+    public int compareTo(@NonNull SMSPeer peer) {
+        return peer.getAddress().compareTo(this.getAddress());
     }
 
     /**


### PR DESCRIPTION
Peer and Message have been changed back to interfaces.
- Peer is now generic on Address and Peer type, to allow comparing only amongst Peers of the same subclass.
- Message Peer and Data order has been reversed cuz lingering OCD.