### PR TITLE
Fixed SMSPeer not accepting emulator addresses.

### DIFF
--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSPeer.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSPeer.java
@@ -23,6 +23,10 @@ public class SMSPeer implements Peer<String, SMSPeer> {
      */
     public static final String DEFAULT_REGION = "IT";
 
+    //Max 3 emulators tested (5554, 5556, 5558)
+    private static final String EMULATOR_REGEX = "\\+1555521555[468]";
+    private static final String SHORT_EMULATOR_REGEX = "555[468]";
+
     private enum Token {
         INVALIDITY_TOKEN
     }
@@ -54,7 +58,7 @@ public class SMSPeer implements Peer<String, SMSPeer> {
      */
     public SMSPeer(@NonNull String address) {
         PhoneNumberValidity validity = getAddressValidity(address);
-        if (validity != PhoneNumberValidity.VALID)
+        if (validity != PhoneNumberValidity.VALID && validity != PhoneNumberValidity.EMULATOR)
             throw new InvalidAddressException(String.format(CON_ERROR, validity.getMessage()));
         this.address = address;
     }
@@ -84,6 +88,8 @@ public class SMSPeer implements Peer<String, SMSPeer> {
      * @return An enum value to indicate the validity state of the address.
      */
     public static PhoneNumberValidity getAddressValidity(@NonNull String address) {
+        if(address.matches(SHORT_EMULATOR_REGEX) || address.matches(EMULATOR_REGEX))
+            return PhoneNumberValidity.EMULATOR;
         try {
             Phonenumber.PhoneNumber number = utils.parse(address, DEFAULT_REGION);
             if (utils.isPossibleNumber(number) && utils.isValidNumber(number))
@@ -134,6 +140,7 @@ public class SMSPeer implements Peer<String, SMSPeer> {
 
         NOT_A_NUMBER("Address is not a phone number."),
         NOT_VALID("Phone number is invalid."),
+        EMULATOR("Phone number might be an emulator's number"),
         VALID("Phone number is valid.");
 
         private String message;

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSPeer.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSPeer.java
@@ -23,9 +23,15 @@ public class SMSPeer implements Peer<String, SMSPeer> {
      */
     public static final String DEFAULT_REGION = "IT";
 
-    //Max 3 emulators tested (5554, 5556, 5558)
-    private static final String EMULATOR_REGEX = "\\+1555521555[468]";
-    private static final String SHORT_EMULATOR_REGEX = "555[468]";
+    /*
+     * Max 3 emulators tested (5554, 5556, 5558).
+     * REGEX_END has been divided to allow better editing of the regex itself when and if
+     * emulator address criteria changes.
+     */
+    private static final String REGEX_END = "555[468]";
+    private static final String SHORT_EMULATOR_REGEX = REGEX_END;
+    private static final String SHORT_EMULATOR_PLUS_REGEX = "\\+" + REGEX_END;
+    private static final String FULL_EMULATOR_REGEX = "\\+1555521" + REGEX_END;
 
     private enum Token {
         INVALIDITY_TOKEN
@@ -88,7 +94,7 @@ public class SMSPeer implements Peer<String, SMSPeer> {
      * @return An enum value to indicate the validity state of the address.
      */
     public static PhoneNumberValidity getAddressValidity(@NonNull String address) {
-        if (address.matches(SHORT_EMULATOR_REGEX) || address.matches(EMULATOR_REGEX))
+        if (address.matches(SHORT_EMULATOR_REGEX) || address.matches(FULL_EMULATOR_REGEX) || address.matches(SHORT_EMULATOR_PLUS_REGEX))
             return PhoneNumberValidity.EMULATOR;
         try {
             Phonenumber.PhoneNumber number = utils.parse(address, DEFAULT_REGION);

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSPeer.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/SMSPeer.java
@@ -88,7 +88,7 @@ public class SMSPeer implements Peer<String, SMSPeer> {
      * @return An enum value to indicate the validity state of the address.
      */
     public static PhoneNumberValidity getAddressValidity(@NonNull String address) {
-        if(address.matches(SHORT_EMULATOR_REGEX) || address.matches(EMULATOR_REGEX))
+        if (address.matches(SHORT_EMULATOR_REGEX) || address.matches(EMULATOR_REGEX))
             return PhoneNumberValidity.EMULATOR;
         try {
             Phonenumber.PhoneNumber number = utils.parse(address, DEFAULT_REGION);
@@ -125,6 +125,7 @@ public class SMSPeer implements Peer<String, SMSPeer> {
 
     /**
      * Two Peers can, by default, be ordered using their address as a key.
+     *
      * @param peer the Peer to compare
      * @return the result of the comparison between the addresses
      */

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/EmulatorAddressTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/EmulatorAddressTest.java
@@ -16,6 +16,8 @@ import static junit.framework.TestCase.fail;
 @RunWith(Parameterized.class)
 public class EmulatorAddressTest {
 
+    private String addressToTest;
+
     /**
      * Parameters for the test, in the form of the various possible emulator addresses.
      */
@@ -30,8 +32,6 @@ public class EmulatorAddressTest {
                 {"+15555215558"},
         };
     }
-
-    private String addressToTest;
 
     /**
      * Public constructor for the test.

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/EmulatorAddressTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/EmulatorAddressTest.java
@@ -1,0 +1,56 @@
+package ingsw.group1.msglibrary;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import ingsw.group1.msglibrary.exceptions.InvalidAddressException;
+
+import static junit.framework.TestCase.fail;
+
+/**
+ * Testing Peers with emulator numbers.
+ *
+ * @author Riccardo De Zen
+ */
+@RunWith(Parameterized.class)
+public class EmulatorAddressTest {
+
+    /**
+     * Parameters for the test, in the form of the various possible emulator addresses.
+     */
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Object[][] params() {
+        return new Object[][]{
+                {"5554"},
+                {"+15555215554"},
+                {"5556"},
+                {"+15555215556"},
+                {"5558"},
+                {"+15555215558"},
+        };
+    }
+
+    private String addressToTest;
+
+    /**
+     * Public constructor for the test.
+     *
+     * @param parameterAddress The address to be tested.
+     */
+    public EmulatorAddressTest(String parameterAddress) {
+        addressToTest = parameterAddress;
+    }
+
+    /**
+     * Testing whether the Constructor actually accepts an emulator address.
+     */
+    @Test
+    public void emulatorAddressConstructorPasses() {
+        try {
+            new SMSPeer(addressToTest);
+        } catch (InvalidAddressException e) {
+            fail();
+        }
+    }
+}

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/EmulatorAddressTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/EmulatorAddressTest.java
@@ -4,6 +4,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import ingsw.group1.msglibrary.exceptions.InvalidAddressException;
 
 import static junit.framework.TestCase.fail;
@@ -16,21 +20,24 @@ import static junit.framework.TestCase.fail;
 @RunWith(Parameterized.class)
 public class EmulatorAddressTest {
 
+    private static final String[] HEADS = new String[]{"555", "+555", "+1555521555"};
+    private static final String[] TAILS = new String[]{"4", "6", "8"};
+
     private String addressToTest;
 
     /**
      * Parameters for the test, in the form of the various possible emulator addresses.
      */
     @Parameterized.Parameters(name = "{index}: {0}")
-    public static Object[][] params() {
-        return new Object[][]{
-                {"5554"},
-                {"+15555215554"},
-                {"5556"},
-                {"+15555215556"},
-                {"5558"},
-                {"+15555215558"},
-        };
+    public static Collection<Object> params() {
+        List<Object> parameters = new ArrayList<>();
+        for (String head : HEADS) {
+            for (String tail : TAILS) {
+                String address = head + tail;
+                parameters.add(address);
+            }
+        }
+        return parameters;
     }
 
     /**

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/MessageProviderStub.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/MessageProviderStub.java
@@ -1,6 +1,6 @@
 package ingsw.group1.msglibrary;
 
-public interface MessageProviderStub<P extends Peer, M extends Message<?,P>>{
+public interface MessageProviderStub<P extends Peer, M extends Message<P,?>>{
 
     /**
      * Generate a random Message and Peer

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/SMSPeerTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/SMSPeerTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(Parameterized.class)
 public class SMSPeerTest {
 
-    private static final int TEST_RUNS = 100;
+    private static final int TEST_RUNS = 1;
     private static final RandomSMSPeerGenerator GENERATOR = new RandomSMSPeerGenerator();
 
     private SMSPeer peer;


### PR DESCRIPTION
Currently supporting only emulator ending with "4", "6", "8".
Both long and short addresses are supported. The enum value for `EMULATOR` is already present and used. SMSPeer accepts addresses returning either `VALID` or `EMULATOR`.