### PR TITLE
Parsers for SMSPeer and SMSMessage, SMSParsingManager for global parsing strategy sharing.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -17,13 +17,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':msglibrary')
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/msglibrary/build.gradle
+++ b/msglibrary/build.gradle
@@ -15,11 +15,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-
     testOptions {
         unitTests.includeAndroidResources = true
         unitTests.returnDefaultValues = true
     }
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
+    buildToolsVersion = '29.0.2'
 }
 
 dependencies {
@@ -27,12 +31,16 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.room:room-runtime:2.2.3'
-    implementation 'com.googlecode.libphonenumber:libphonenumber:8.2.0'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.11.2'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'org.mockito:mockito-core:2.28.2'
+    testImplementation "org.powermock:powermock-module-junit4:1.6.6"
+    testImplementation "org.powermock:powermock-module-junit4-rule:1.6.6"
+    testImplementation "org.powermock:powermock-api-mockito:1.6.6"
+    testImplementation "org.powermock:powermock-classloading-xstream:1.6.6"
 
     androidTestImplementation 'androidx.test:core:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/exceptions/UnparsableMessageException.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/exceptions/UnparsableMessageException.java
@@ -1,0 +1,23 @@
+package ingsw.group1.msglibrary.exceptions;
+
+/**
+ * Exception meant to be thrown when an attempt to parse an unparsable {@code Message} is made.
+ *
+ * @author Riccardo De Zen
+ */
+public class UnparsableMessageException extends IllegalArgumentException {
+    /**
+     * Default constructor. Calls {@link IllegalArgumentException#IllegalArgumentException()}.
+     */
+    public UnparsableMessageException(){
+        super();
+    }
+
+    /**
+     * Constructor calling {@link IllegalArgumentException#IllegalArgumentException(String)}.
+     * @param message The message for this Exception.
+     */
+    public UnparsableMessageException(String message){
+        super(message);
+    }
+}

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/exceptions/UnsendableMessageException.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/exceptions/UnsendableMessageException.java
@@ -1,0 +1,23 @@
+package ingsw.group1.msglibrary.exceptions;
+
+/**
+ * Exception meant to be thrown when an attempt to send an unsendable {@code Message} is made.
+ *
+ * @author Riccardo De Zen
+ */
+public class UnsendableMessageException extends IllegalArgumentException {
+    /**
+     * Default constructor. Calls {@link IllegalArgumentException#IllegalArgumentException()}.
+     */
+    public UnsendableMessageException(){
+        super();
+    }
+
+    /**
+     * Constructor calling {@link IllegalArgumentException#IllegalArgumentException(String)}.
+     * @param message The message for this Exception.
+     */
+    public UnsendableMessageException(String message){
+        super(message);
+    }
+}

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/MessageParser.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/MessageParser.java
@@ -1,0 +1,25 @@
+package ingsw.group1.msglibrary.parsing;
+
+import ingsw.group1.msglibrary.Message;
+
+/**
+ * Interface defining standard behaviour for a class aiming to manage sent and incoming {@code
+ * Message} parsing.
+ *
+ * @param <M> The type of {@code Message} the Parser parses.
+ * @author Riccardo De Zen
+ */
+public interface MessageParser<M extends Message> {
+    /**
+     * @param message The outgoing {@code Message}.
+     * @return The formatted {@code Message}, ready to be sent.
+     */
+    M parseOutgoingMessage(M message);
+
+    /**
+     * @param message The incoming {@code Message}.
+     * @return The parsed {@code Message}, as it would be before a
+     * {@link MessageParser#parseOutgoingMessage(Message)} call.
+     */
+    M parseIncomingMessage(M message);
+}

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/PeerParser.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/PeerParser.java
@@ -1,0 +1,25 @@
+package ingsw.group1.msglibrary.parsing;
+
+import ingsw.group1.msglibrary.Peer;
+
+/**
+ * Interface defining standard behaviour for a class aiming to convert between a type of data
+ * ({@code D}) and a type of Peer ({@code P}).
+ *
+ * @param <P> The type of Peer this Parser parses.
+ * @param <D> The type of data this Parser uses.
+ * @author Riccardo De Zen
+ */
+public interface PeerParser<P extends Peer, D> {
+    /**
+     * @param peer The {@code Peer} to convert into data.
+     * @return The converted {@code Peer}.
+     */
+    D peerToData(P peer);
+
+    /**
+     * @param data The data to be parsed.
+     * @return The Peer contained in the data.
+     */
+    P dataToPeer(D data);
+}

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/PeerParser.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/PeerParser.java
@@ -19,7 +19,7 @@ public interface PeerParser<P extends Peer, D> {
 
     /**
      * @param data The data to be parsed.
-     * @return The Peer contained in the data.
+     * @return The {@code Peer} obtained from the data.
      */
     P dataToPeer(D data);
 }

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSParser.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSParser.java
@@ -1,0 +1,11 @@
+package ingsw.group1.msglibrary.parsing;
+
+import ingsw.group1.msglibrary.SMSMessage;
+
+/**
+ * This interface is just a declaration of the {@link MessageParser} for {@link SMSMessage}.
+ *
+ * @author Riccardo De Zen
+ */
+public interface SMSParser extends MessageParser<SMSMessage> {
+}

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSParsingManager.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSParsingManager.java
@@ -2,12 +2,11 @@ package ingsw.group1.msglibrary.parsing;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.util.ArrayMap;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.lang.ref.WeakReference;
+import java.util.HashMap;
 import java.util.Map;
 
 import ingsw.group1.msglibrary.SMSMessage;
@@ -18,8 +17,14 @@ import ingsw.group1.msglibrary.SMSMessage;
  * By default also acts as a parser that does no operation on the messages. Allows setting a new
  * parser to override the one in use by the current instance by calling
  * {@link SMSParsingManager#setOverridingParser(Class)}, such a change persists, since it is
- * stored in {@link android.content.SharedPreferences}, with a key which is:
- * {@link SMSParsingManager#PREF_KEY} + {@link SMSParsingManager#instanceName}.
+ * stored in {@link android.content.SharedPreferences}, in a file called
+ * {@link SMSParsingManager#PREF_FILENAME} with a key which is:
+ * {@link SMSParsingManager#PREF_KEY_PREFIX} + {@link SMSParsingManager#instanceName}.
+ * <p>
+ * In order to be instantiated the Parser class needs a public constructor with no parameters.
+ * Since the raw class name is stored, generics are not supported. If you need one of the
+ * previously stated features, move the parsing logic to an upper level.
+ * <p>
  * Also allows resetting to the default parsing strategy by calling
  * {@link SMSParsingManager#resetOverridingParser()}.
  *
@@ -30,13 +35,16 @@ public class SMSParsingManager implements SMSParser {
     //Base name for Preference file name.
     static final String PREF_FILENAME = "ingsw.group1.msglibrary.parsing.SMSParsingManager";
     //Base name for Preference key. Should be followed by instance name.
-    static final String PREF_KEY = "defaultParser-";
+    static final String PREF_KEY_PREFIX = "defaultParser-";
     //Map containing the active instances of this class.
-    private static Map<String, SMSParsingManager> activeInstances = new ArrayMap<>();
+    private static Map<String, SMSParsingManager> activeInstances = new HashMap<>();
 
-    private WeakReference<Context> context;
+    private final String PREF_KEY;
     private SharedPreferences parsingPreferences;
     private String instanceName;
+
+    @Nullable
+    private SMSParser overridingParser;
 
     /**
      * Private constructor for this class.
@@ -45,9 +53,10 @@ public class SMSParsingManager implements SMSParser {
      * @param instanceName The name for this instance. Must not be {@code null}.
      */
     private SMSParsingManager(@NonNull Context context, @NonNull String instanceName) {
-        this.context = new WeakReference<>(context.getApplicationContext());
-        this.parsingPreferences = context.getSharedPreferences(PREF_FILENAME, Context.MODE_PRIVATE);
+        this.parsingPreferences = getPreferences(context);
         this.instanceName = instanceName;
+        this.PREF_KEY = PREF_KEY_PREFIX + instanceName;
+        this.overridingParser = instantiateOverridingParser();
     }
 
     /**
@@ -70,22 +79,116 @@ public class SMSParsingManager implements SMSParser {
     }
 
     /**
-     * @param newParser A reference to the class defining the new overriding parser.
+     * Getter for {@link SMSParsingManager#instanceName}.
+     *
+     * @return {@link SMSParsingManager#instanceName}, the name for this instance.
+     */
+    @NonNull
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    /**
+     * Method to retrieve the {@link SharedPreferences}.
+     *
+     * @param context The {@link Context} from which to retrieve the {@link SharedPreferences}.
+     * @return The appropriate instance of {@link SharedPreferences}.
+     */
+    private SharedPreferences getPreferences(Context context) {
+        return context.getSharedPreferences(
+                PREF_FILENAME,
+                Context.MODE_PRIVATE
+        );
+    }
+
+    /**
+     * Method to save a value in the appropriate field {@link SharedPreferences}.
+     * Apply is used as suggested by the compiler in order to write to Preferences in the
+     * background, to let Android framework handle failures properly.
+     *
+     * @param newValue The new value for the field, can be null.
+     * @return The previously stored value.
      */
     @Nullable
-    public <P extends SMSParser> Class<P> setOverridingParser(@NonNull Class<P> newParser) {
-        return null;
+    private String storeInPreferences(@Nullable String newValue) {
+        String oldValue = parsingPreferences.getString(PREF_KEY, null);
+        SharedPreferences.Editor prefEditor = parsingPreferences.edit();
+        prefEditor.putString(PREF_KEY, newValue);
+        prefEditor.apply();
+        return oldValue;
+    }
+
+    /**
+     * Method setting the new Parser, this method saves the class' name in the
+     * {@link SharedPreferences}, in a file called {@link SMSParsingManager#PREF_FILENAME}, in a
+     * field called: {@link SMSParsingManager#PREF_KEY_PREFIX} +
+     * {@link SMSParsingManager#instanceName}.
+     *
+     * @param newParser A reference to the class defining the new overriding parser.
+     * @return The previously stored class, no type check are performed on the stored class
+     * except whether it extends {@link SMSParser}. Returns {@code null} if the class could not
+     * be found or it did not extend {@link SMSParser}.
+     */
+    @Nullable
+    public Class<? extends SMSParser> setOverridingParser(@NonNull Class<? extends SMSParser> newParser) {
+        Class<? extends SMSParser> oldStoredClass = getOverridingParser();
+        storeInPreferences(newParser.getName());
+        overridingParser = instantiateOverridingParser();
+        return oldStoredClass;
+    }
+
+    /**
+     * Getter for the saved parser class.
+     *
+     * @return The reference to the currently set {@link SMSParser} class. The Type of stored
+     * class is not questioned (as long as it extends {@link SMSParser}).
+     */
+    @Nullable
+    public Class<? extends SMSParser> getOverridingParser() {
+        String storedValue = parsingPreferences.getString(PREF_KEY, null);
+        if (storedValue == null) return null;
+        try {
+            Class<?> storedClass = Class.forName(storedValue);
+            if (SMSParser.class.isAssignableFrom(storedClass))
+                //The cast is safe due to the above check.
+                return (Class<? extends SMSParser>) storedClass;
+            else
+                return null;
+        } catch (ClassNotFoundException e) {
+            //The class might have been renamed or its name might have been inappropriately stored.
+            return null;
+        }
     }
 
     /**
      * Method resetting the parser this instance uses to the default (no operation on messages).
      *
      * @return The reference to the previously set {@link SMSParser} class. The Type of stored
-     * class is not questioned (as long as it extends {@link SMSParser}.
+     * class is not questioned (as long as it extends {@link SMSParser}).
      */
     @Nullable
     public Class<? extends SMSParser> resetOverridingParser() {
-        return null;
+        Class<? extends SMSParser> oldStoredClass = getOverridingParser();
+        storeInPreferences(null);
+        overridingParser = instantiateOverridingParser();
+        return oldStoredClass;
+    }
+
+    /**
+     * Method to create an instance of the Overriding parser class. If the class cannot be
+     * instantiated, the instance is left {@code null};
+     *
+     * @return The instance of the stored class, can be {@code null}.
+     */
+    @Nullable
+    private SMSParser instantiateOverridingParser() {
+        Class<? extends SMSParser> overridingClass = getOverridingParser();
+        if (overridingClass == null) return null;
+        try {
+            return overridingClass.newInstance();
+        } catch (IllegalAccessException | InstantiationException e) {
+            return null;
+        }
     }
 
     /**
@@ -94,7 +197,8 @@ public class SMSParsingManager implements SMSParser {
      */
     @Override
     public SMSMessage parseOutgoingMessage(SMSMessage message) {
-        return message;
+        if (overridingParser == null) return message;
+        return overridingParser.parseOutgoingMessage(message);
     }
 
     /**
@@ -104,6 +208,7 @@ public class SMSParsingManager implements SMSParser {
      */
     @Override
     public SMSMessage parseIncomingMessage(SMSMessage message) {
-        return message;
+        if (overridingParser == null) return message;
+        return overridingParser.parseIncomingMessage(message);
     }
 }

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSParsingManager.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSParsingManager.java
@@ -1,0 +1,109 @@
+package ingsw.group1.msglibrary.parsing;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.ArrayMap;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+
+import ingsw.group1.msglibrary.SMSMessage;
+
+/**
+ * Class implementing {@link MessageParser} for {@link SMSMessage}.
+ * The class behaves as an Object Pool, requiring a String name to get an appropriate instance.
+ * By default also acts as a parser that does no operation on the messages. Allows setting a new
+ * parser to override the one in use by the current instance by calling
+ * {@link SMSParsingManager#setOverridingParser(Class)}, such a change persists, since it is
+ * stored in {@link android.content.SharedPreferences}, with a key which is:
+ * {@link SMSParsingManager#PREF_KEY} + {@link SMSParsingManager#instanceName}.
+ * Also allows resetting to the default parsing strategy by calling
+ * {@link SMSParsingManager#resetOverridingParser()}.
+ *
+ * @author Riccardo De Zen
+ */
+public class SMSParsingManager implements SMSParser {
+
+    //Base name for Preference file name.
+    static final String PREF_FILENAME = "ingsw.group1.msglibrary.parsing.SMSParsingManager";
+    //Base name for Preference key. Should be followed by instance name.
+    static final String PREF_KEY = "defaultParser-";
+    //Map containing the active instances of this class.
+    private static Map<String, SMSParsingManager> activeInstances = new ArrayMap<>();
+
+    private WeakReference<Context> context;
+    private SharedPreferences parsingPreferences;
+    private String instanceName;
+
+    /**
+     * Private constructor for this class.
+     *
+     * @param context      The calling Context. Must not be {@code null}.
+     * @param instanceName The name for this instance. Must not be {@code null}.
+     */
+    private SMSParsingManager(@NonNull Context context, @NonNull String instanceName) {
+        this.context = new WeakReference<>(context.getApplicationContext());
+        this.parsingPreferences = context.getSharedPreferences(PREF_FILENAME, Context.MODE_PRIVATE);
+        this.instanceName = instanceName;
+    }
+
+    /**
+     * Method to get an Instance of this class, associated with the appropriate name.
+     *
+     * @param context The calling {@link Context}, used to access
+     *                {@link android.content.SharedPreferences} to store the name of the
+     *                overriding parser class. Must not be {@code null}.
+     * @param name    The name for the instance. Must not be {@code null}.
+     * @return A properly initialized instance of SMSParser.
+     */
+    @NonNull
+    public static SMSParsingManager getInstance(@NonNull Context context, @NonNull String name) {
+        SMSParsingManager existingInstance = activeInstances.get(name);
+        if (existingInstance != null)
+            return existingInstance;
+        SMSParsingManager newInstance = new SMSParsingManager(context, name);
+        activeInstances.put(name, newInstance);
+        return newInstance;
+    }
+
+    /**
+     * @param newParser A reference to the class defining the new overriding parser.
+     */
+    @Nullable
+    public <P extends SMSParser> Class<P> setOverridingParser(@NonNull Class<P> newParser) {
+        return null;
+    }
+
+    /**
+     * Method resetting the parser this instance uses to the default (no operation on messages).
+     *
+     * @return The reference to the previously set {@link SMSParser} class. The Type of stored
+     * class is not questioned (as long as it extends {@link SMSParser}.
+     */
+    @Nullable
+    public Class<? extends SMSParser> resetOverridingParser() {
+        return null;
+    }
+
+    /**
+     * @param message The outgoing {@link SMSMessage}. This is not modified, a new one is created.
+     * @return The formatted {@link SMSMessage}, ready to be sent.
+     */
+    @Override
+    public SMSMessage parseOutgoingMessage(SMSMessage message) {
+        return message;
+    }
+
+    /**
+     * @param message The incoming {@link SMSMessage}.
+     * @return The parsed {@link SMSMessage}, as it would be before a
+     * {@link SMSParsingManager#parseOutgoingMessage(SMSMessage)} call.
+     */
+    @Override
+    public SMSMessage parseIncomingMessage(SMSMessage message) {
+        return message;
+    }
+}

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSParsingManager.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSParsingManager.java
@@ -33,9 +33,9 @@ import ingsw.group1.msglibrary.SMSMessage;
 public class SMSParsingManager implements SMSParser {
 
     //Base name for Preference file name.
-    static final String PREF_FILENAME = "ingsw.group1.msglibrary.parsing.SMSParsingManager";
+    private static final String PREF_FILENAME = "ingsw.group1.msglibrary.parsing.SMSParsingManager";
     //Base name for Preference key. Should be followed by instance name.
-    static final String PREF_KEY_PREFIX = "defaultParser-";
+    private static final String PREF_KEY_PREFIX = "defaultParser-";
     //Map containing the active instances of this class.
     private static Map<String, SMSParsingManager> activeInstances = new HashMap<>();
 

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSPeerParser.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSPeerParser.java
@@ -18,8 +18,8 @@ public class SMSPeerParser implements PeerParser<SMSPeer, String> {
 
     /**
      * @param peer The valid {@code SMSPeer} to convert into data. Must not be {@code null}.
-     * @return The converted {@code SMSPeer} in {@code String} format, returns null for an
-     * invalid {@code peer}.
+     * @return The converted {@code SMSPeer} in {@code String} format, more precisely a {@code
+     * String} containing the address, returns null if {@code peer} is invalid.
      */
     @Nullable
     public String peerToData(@NonNull SMSPeer peer) {
@@ -29,16 +29,19 @@ public class SMSPeerParser implements PeerParser<SMSPeer, String> {
     }
 
     /**
-     * @param data The data to be parsed. A valid address is expected as data. Must not be {@code
-     *             null}.
+     * @param data The data to be parsed. A {@code String} containing a valid address is expected
+     *             as data. Must not be {@code null}.
      * @return The {@code SMSPeer} obtained from the data.
-     * @throws InvalidAddressException if {@code data} was not a valid address.
+     * @throws InvalidAddressException If {@code data} was not a valid address.
      */
     @NonNull
     public SMSPeer dataToPeer(@NonNull String data) throws InvalidAddressException {
-        SMSPeer.PhoneNumberValidity validity = SMSPeer.getAddressValidity(data);
-        if (validity != SMSPeer.PhoneNumberValidity.VALID)
-            throw new InvalidAddressException(String.format(PARSE_ERR, validity));
-        return new SMSPeer(data);
+        try {
+            return new SMSPeer(data);
+        } catch (InvalidAddressException e) {
+            throw new IllegalArgumentException(
+                    String.format(PARSE_ERR, SMSPeer.getAddressValidity(data))
+            );
+        }
     }
 }

--- a/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSPeerParser.java
+++ b/msglibrary/src/main/java/ingsw/group1/msglibrary/parsing/SMSPeerParser.java
@@ -1,0 +1,44 @@
+package ingsw.group1.msglibrary.parsing;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import ingsw.group1.msglibrary.SMSPeer;
+import ingsw.group1.msglibrary.exceptions.InvalidAddressException;
+
+/**
+ * Class defining an implementation of a {@link PeerParser} for
+ * {@link ingsw.group1.msglibrary.SMSPeer}.
+ *
+ * @author Riccardo De Zen
+ */
+public class SMSPeerParser implements PeerParser<SMSPeer, String> {
+
+    private static final String PARSE_ERR = "Data was not a valid address. Validity result: %s";
+
+    /**
+     * @param peer The valid {@code SMSPeer} to convert into data. Must not be {@code null}.
+     * @return The converted {@code SMSPeer} in {@code String} format, returns null for an
+     * invalid {@code peer}.
+     */
+    @Nullable
+    public String peerToData(@NonNull SMSPeer peer) {
+        if (peer.isValid())
+            return peer.getAddress();
+        return null;
+    }
+
+    /**
+     * @param data The data to be parsed. A valid address is expected as data. Must not be {@code
+     *             null}.
+     * @return The {@code SMSPeer} obtained from the data.
+     * @throws InvalidAddressException if {@code data} was not a valid address.
+     */
+    @NonNull
+    public SMSPeer dataToPeer(@NonNull String data) throws InvalidAddressException {
+        SMSPeer.PhoneNumberValidity validity = SMSPeer.getAddressValidity(data);
+        if (validity != SMSPeer.PhoneNumberValidity.VALID)
+            throw new InvalidAddressException(String.format(PARSE_ERR, validity));
+        return new SMSPeer(data);
+    }
+}

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSParsingManagerTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSParsingManagerTest.java
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -34,14 +35,15 @@ import static org.junit.Assert.assertNull;
 @RunWith(RobolectricTestRunner.class)
 public class SMSParsingManagerTest {
 
-    private static final String PREF_FILENAME = SMSParsingManager.PREF_FILENAME;
-    private static final String PREF_KEY_PREFIX = SMSParsingManager.PREF_KEY_PREFIX;
     private static final String EXAMPLE_NAME = "I'm a name";
     private static final String ANOTHER_NAME = "Another name";
     private static final SMSMessage EXAMPLE_MESSAGE = new SMSMessage(
             new RandomSMSPeerGenerator().generateValidPeer(),
             "I'm an example message"
     );
+
+    private static String PREF_FILENAME;
+    private static String PREF_KEY_PREFIX;
 
     private SMSParsingManager parsingManager;
     private String prefKey;
@@ -78,6 +80,27 @@ public class SMSParsingManagerTest {
         @Override
         public SMSMessage parseIncomingMessage(SMSMessage message) {
             return new SMSMessage(message.getPeer(), message.getData().substring(1));
+        }
+    }
+
+    /**
+     * Method to initialize the constants used by {@link SMSParsingManager} in order to inject
+     * data in the correct preference files.
+     */
+    @BeforeClass
+    public static void setPrefFilenameAndKey() {
+        try {
+            Field prefFileField = SMSParsingManager.class.getDeclaredField("PREF_FILENAME");
+            prefFileField.setAccessible(true);
+            PREF_FILENAME = (String) prefFileField.get(null);
+
+            Field prefKeyField = SMSParsingManager.class.getDeclaredField("PREF_KEY_PREFIX");
+            prefKeyField.setAccessible(true);
+            PREF_KEY_PREFIX = (String) prefKeyField.get(null);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException(
+                    "The constants could not be set. Tests cannot be run\n" + e.getMessage()
+            );
         }
     }
 

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSParsingManagerTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSParsingManagerTest.java
@@ -20,6 +20,7 @@ import ingsw.group1.msglibrary.SMSMessage;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Class containing tests for {@link SMSParsingManager}.
@@ -155,7 +156,7 @@ public class SMSParsingManagerTest {
     }
 
     /**
-     * // FIXME: 19/01/2020 The preference is read as null from outside on separated tests.
+     * // FIXME: 19/01/2020 An attempt to read the value in between write and read returns null.
      * Test to assert the class can write the parser class in
      * {@link android.content.SharedPreferences} and subsequently retrieve it, when starting from
      * a {@code null} value.
@@ -184,13 +185,21 @@ public class SMSParsingManagerTest {
      * for the saved parser.
      */
     @Test
-    public void setParsingManagerReturnsOldValue() {
+    public void setOverridingParserReturnsOldValue() {
         parsingManager.setOverridingParser(ExampleSMSParser.class);
         Class<?> oldValue = parsingManager.setOverridingParser(AnotherExampleSMSParser.class);
         assertEquals(ExampleSMSParser.class, oldValue);
     }
 
-    //TODO reset tests
+    /**
+     * Test to assert {@link SMSParsingManager#setOverridingParser(Class)} resets to null.
+     */
+    @Test
+    public void resetOverridingParser() {
+        parsingManager.setOverridingParser(ExampleSMSParser.class);
+        parsingManager.resetOverridingParser();
+        assertNull(parsingManager.getOverridingParser());
+    }
 
     /**
      * Test asserting the parser actually overrides for outgoing messages.

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSParsingManagerTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSParsingManagerTest.java
@@ -1,0 +1,100 @@
+package ingsw.group1.msglibrary.parsing;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import ingsw.group1.msglibrary.SMSMessage;
+
+/**
+ * Class containing tests for {@link SMSParsingManager}.
+ * Robolectric is used to mock {@link android.content.SharedPreferences} automatically.
+ *
+ * @author Riccardo De Zen
+ */
+@RunWith(RobolectricTestRunner.class)
+public class SMSParsingManagerTest {
+
+    private static final String PREF_FILENAME = SMSParsingManager.PREF_FILENAME;
+    private static final String PREF_KEY = SMSParsingManager.PREF_KEY;
+
+    private SMSParsingManager parsingManager;
+
+    /**
+     * Test to assert the class works as a proper key-based Object Pool: same key means same
+     * instance.
+     */
+    @Test
+    public void sameNameInstancesAreSame() {
+
+    }
+
+    /**
+     * Test to assert the class works as a proper key-based Object Pool: different key means
+     * different instance.
+     */
+    @Test
+    public void differentNameInstancesAreDifferent() {
+
+    }
+
+    /**
+     * Test to assert {@link SMSParsingManager#parseOutgoingMessage(SMSMessage)} actually does
+     * nothing by default.
+     */
+    @Test
+    public void parseOutgoingDoesNothingByDefault() {
+
+    }
+
+    /**
+     * Test to assert {@link SMSParsingManager#parseIncomingMessage(SMSMessage)} actually does
+     * nothing by default.
+     */
+    @Test
+    public void parseIncomingDoesNothingByDefault() {
+
+    }
+
+    /**
+     * Test to assert the class can write the parser class in
+     * {@link android.content.SharedPreferences}.
+     */
+    @Test
+    public void canSetParser() {
+
+    }
+
+    /**
+     * Test to assert {@link SMSParsingManager#setOverridingParser(Class)} returns the old value
+     * for the saved parser.
+     */
+    @Test
+    public void setParsingManagerReturnsOldValue() {
+
+    }
+
+    /**
+     * Test asserting the class can get the previously saved parser class.
+     */
+    @Test
+    public void canGetParser() {
+
+    }
+
+    /**
+     * Test asserting the parser actually overrides for outgoing messages.
+     */
+    @Test
+    public void isOutgoingParsingOverridden() {
+
+    }
+
+    /**
+     * Test asserting the parser actually overrides for incoming messages.
+     */
+    @Test
+    public void isIncomingParsingOverridden() {
+
+    }
+}

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSParsingManagerTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSParsingManagerTest.java
@@ -1,10 +1,25 @@
 package ingsw.group1.msglibrary.parsing;
 
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import ingsw.group1.msglibrary.RandomSMSPeerGenerator;
 import ingsw.group1.msglibrary.SMSMessage;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * Class containing tests for {@link SMSParsingManager}.
@@ -12,13 +27,82 @@ import ingsw.group1.msglibrary.SMSMessage;
  *
  * @author Riccardo De Zen
  */
+@Config(sdk = 28)
 @RunWith(RobolectricTestRunner.class)
 public class SMSParsingManagerTest {
 
     private static final String PREF_FILENAME = SMSParsingManager.PREF_FILENAME;
-    private static final String PREF_KEY = SMSParsingManager.PREF_KEY;
+    private static final String PREF_KEY = SMSParsingManager.PREF_KEY_PREFIX;
+    private static final String EXAMPLE_NAME = "I'm a name";
+    private static final String ANOTHER_NAME = "Another name";
+    private static final SMSMessage EXAMPLE_MESSAGE = new SMSMessage(
+            new RandomSMSPeerGenerator().generateValidPeer(),
+            "I'm an example message"
+    );
 
     private SMSParsingManager parsingManager;
+
+    private Context context;
+
+    /**
+     * Example parser to test the set and read feature in {@link SMSParsingManager}. It is
+     * relevant for this class to be a private child class because the way their name is written
+     * influences the reflection mechanisms used to instantiate the class.
+     */
+    private static class ExampleSMSParser implements SMSParser {
+
+        @Override
+        public SMSMessage parseOutgoingMessage(SMSMessage message) {
+            return new SMSMessage(message.getPeer(), "#" + message.getData());
+        }
+
+        @Override
+        public SMSMessage parseIncomingMessage(SMSMessage message) {
+            return new SMSMessage(message.getPeer(), message.getData().substring(1));
+        }
+    }
+
+    /**
+     * Another example parser, to test ability to get the previously stored value.
+     */
+    private static class AnotherExampleSMSParser implements SMSParser {
+
+        @Override
+        public SMSMessage parseOutgoingMessage(SMSMessage message) {
+            return new SMSMessage(message.getPeer(), "#" + message.getData());
+        }
+
+        @Override
+        public SMSMessage parseIncomingMessage(SMSMessage message) {
+            return new SMSMessage(message.getPeer(), message.getData().substring(1));
+        }
+    }
+
+    /**
+     * Method to initialize {@link Context} through {@link RobolectricTestRunner}.
+     */
+    @Before
+    public void initContext() {
+        context = ApplicationProvider.getApplicationContext();
+        parsingManager = SMSParsingManager.getInstance(context, EXAMPLE_NAME);
+    }
+
+    /**
+     * Method to reset the instances of the {@link SMSParsingManager} class, to reset Preferences
+     * as well.
+     */
+    @After
+    public void resetInstances() {
+        try {
+            Field instances = SMSParsingManager.class.getDeclaredField("activeInstances");
+            instances.setAccessible(true);
+            Map<?, ?> instancesMap = (Map<?, ?>) instances.get(null);
+            if (instancesMap != null) instancesMap.clear();
+            else throw new NoSuchFieldException("Instance Map was null");
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException("Instances could not be reset due to: " + e.getMessage());
+        }
+    }
 
     /**
      * Test to assert the class works as a proper key-based Object Pool: same key means same
@@ -26,7 +110,10 @@ public class SMSParsingManagerTest {
      */
     @Test
     public void sameNameInstancesAreSame() {
-
+        assertEquals(
+                SMSParsingManager.getInstance(context, EXAMPLE_NAME),
+                SMSParsingManager.getInstance(context, EXAMPLE_NAME)
+        );
     }
 
     /**
@@ -35,7 +122,10 @@ public class SMSParsingManagerTest {
      */
     @Test
     public void differentNameInstancesAreDifferent() {
-
+        assertNotEquals(
+                SMSParsingManager.getInstance(context, EXAMPLE_NAME),
+                SMSParsingManager.getInstance(context, ANOTHER_NAME)
+        );
     }
 
     /**
@@ -44,7 +134,11 @@ public class SMSParsingManagerTest {
      */
     @Test
     public void parseOutgoingDoesNothingByDefault() {
-
+        SMSMessage parsedMessage = parsingManager.parseOutgoingMessage(EXAMPLE_MESSAGE);
+        assertTrue(
+                EXAMPLE_MESSAGE.getPeer().equals(parsedMessage.getPeer()) &&
+                        EXAMPLE_MESSAGE.getData().equals(parsedMessage.getData())
+        );
     }
 
     /**
@@ -53,16 +147,36 @@ public class SMSParsingManagerTest {
      */
     @Test
     public void parseIncomingDoesNothingByDefault() {
-
+        SMSMessage parsedMessage = parsingManager.parseIncomingMessage(EXAMPLE_MESSAGE);
+        assertTrue(
+                EXAMPLE_MESSAGE.getPeer().equals(parsedMessage.getPeer()) &&
+                        EXAMPLE_MESSAGE.getData().equals(parsedMessage.getData())
+        );
     }
 
     /**
+     * // FIXME: 19/01/2020 The preference is read as null from outside on separated tests.
      * Test to assert the class can write the parser class in
-     * {@link android.content.SharedPreferences}.
+     * {@link android.content.SharedPreferences} and subsequently retrieve it, when starting from
+     * a {@code null} value.
      */
     @Test
-    public void canSetParser() {
+    public void canSetAndGetParserFromNull() {
+        parsingManager.setOverridingParser(ExampleSMSParser.class);
+        assertEquals(ExampleSMSParser.class, parsingManager.getOverridingParser());
+    }
 
+    /**
+     * // FIXME: 19/01/2020 Same as above test.
+     * Test to assert the class can write the parser class in
+     * {@link android.content.SharedPreferences} and subsequently retrieve it, when starting from
+     * some other already set value.
+     */
+    @Test
+    public void canSetAndGetParserFromAlreadySet() {
+        parsingManager.setOverridingParser(ExampleSMSParser.class);
+        parsingManager.setOverridingParser(AnotherExampleSMSParser.class);
+        assertEquals(AnotherExampleSMSParser.class, parsingManager.getOverridingParser());
     }
 
     /**
@@ -71,23 +185,25 @@ public class SMSParsingManagerTest {
      */
     @Test
     public void setParsingManagerReturnsOldValue() {
-
+        parsingManager.setOverridingParser(ExampleSMSParser.class);
+        Class<?> oldValue = parsingManager.setOverridingParser(AnotherExampleSMSParser.class);
+        assertEquals(ExampleSMSParser.class, oldValue);
     }
 
-    /**
-     * Test asserting the class can get the previously saved parser class.
-     */
-    @Test
-    public void canGetParser() {
-
-    }
+    //TODO reset tests
 
     /**
      * Test asserting the parser actually overrides for outgoing messages.
      */
     @Test
     public void isOutgoingParsingOverridden() {
-
+        parsingManager.setOverridingParser(ExampleSMSParser.class);
+        SMSMessage actualParsedMessage = parsingManager.parseOutgoingMessage(EXAMPLE_MESSAGE);
+        SMSMessage expectedParsedMessage = parsingManager.parseOutgoingMessage(EXAMPLE_MESSAGE);
+        assertTrue(
+                expectedParsedMessage.getPeer().equals(actualParsedMessage.getPeer()) &&
+                        expectedParsedMessage.getData().equals(actualParsedMessage.getData())
+        );
     }
 
     /**
@@ -95,6 +211,12 @@ public class SMSParsingManagerTest {
      */
     @Test
     public void isIncomingParsingOverridden() {
-
+        parsingManager.setOverridingParser(ExampleSMSParser.class);
+        SMSMessage actualParsedMessage = parsingManager.parseOutgoingMessage(EXAMPLE_MESSAGE);
+        SMSMessage expectedParsedMessage = parsingManager.parseOutgoingMessage(EXAMPLE_MESSAGE);
+        assertTrue(
+                expectedParsedMessage.getPeer().equals(actualParsedMessage.getPeer()) &&
+                        expectedParsedMessage.getData().equals(actualParsedMessage.getData())
+        );
     }
 }

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSPeerParserTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSPeerParserTest.java
@@ -30,12 +30,12 @@ public class SMSPeerParserTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void dataToPeerThrowsForInvalidAddress(){
+    public void dataToPeerThrowsForInvalidAddress() {
         parser.dataToPeer(new RandomSMSPeerGenerator().generateInvalidAddress());
     }
 
     @Test
-    public void dataToPeerAcceptsValidAddress(){
+    public void dataToPeerAcceptsValidAddress() {
         String peerData = new RandomSMSPeerGenerator().generateValidAddress();
         SMSPeer expected = new SMSPeer(peerData);
         assertEquals(expected, parser.dataToPeer(peerData));

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSPeerParserTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSPeerParserTest.java
@@ -1,0 +1,47 @@
+package ingsw.group1.msglibrary.parsing;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import ingsw.group1.msglibrary.RandomSMSPeerGenerator;
+import ingsw.group1.msglibrary.SMSPeer;
+import ingsw.group1.msglibrary.exceptions.InvalidAddressException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for {@link SMSPeerParser}. Tests assume positive results for
+ * {@link ingsw.group1.msglibrary.RandomSMSPeerGeneratorTest}.
+ *
+ * @author Riccardo De Zen
+ */
+public class SMSPeerParserTest {
+    private SMSPeerParser parser = new SMSPeerParser();
+
+    @Test
+    public void peerToDataAcceptsValid() {
+        String validAddress = new RandomSMSPeerGenerator().generateValidAddress();
+        SMSPeer peer = new SMSPeer(validAddress);
+        assertEquals(validAddress, parser.peerToData(peer));
+    }
+
+    @Test
+    public void peerToDataReturnsNullForInvalid() {
+        Assert.assertNull(parser.peerToData(SMSPeer.INVALID_SMS_PEER));
+    }
+
+    //TODO test should run on all enum values
+    @Test(expected = InvalidAddressException.class)
+    public void dataToPeerThrowsForInvalidAddress(){
+        parser.dataToPeer(new RandomSMSPeerGenerator().generateInvalidAddress());
+    }
+
+    @Test
+    public void dataToPeerAcceptsValidAddress(){
+        SMSPeer peer = new RandomSMSPeerGenerator().generateValidPeer();
+        String peerData = parser.peerToData(peer);
+        assertNotNull(peerData);
+        assertEquals(peer, parser.dataToPeer(peerData));
+    }
+}

--- a/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSPeerParserTest.java
+++ b/msglibrary/src/test/java/ingsw/group1/msglibrary/parsing/SMSPeerParserTest.java
@@ -5,10 +5,8 @@ import org.junit.Test;
 
 import ingsw.group1.msglibrary.RandomSMSPeerGenerator;
 import ingsw.group1.msglibrary.SMSPeer;
-import ingsw.group1.msglibrary.exceptions.InvalidAddressException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests for {@link SMSPeerParser}. Tests assume positive results for
@@ -31,17 +29,15 @@ public class SMSPeerParserTest {
         Assert.assertNull(parser.peerToData(SMSPeer.INVALID_SMS_PEER));
     }
 
-    //TODO test should run on all enum values
-    @Test(expected = InvalidAddressException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void dataToPeerThrowsForInvalidAddress(){
         parser.dataToPeer(new RandomSMSPeerGenerator().generateInvalidAddress());
     }
 
     @Test
     public void dataToPeerAcceptsValidAddress(){
-        SMSPeer peer = new RandomSMSPeerGenerator().generateValidPeer();
-        String peerData = parser.peerToData(peer);
-        assertNotNull(peerData);
-        assertEquals(peer, parser.dataToPeer(peerData));
+        String peerData = new RandomSMSPeerGenerator().generateValidAddress();
+        SMSPeer expected = new SMSPeer(peerData);
+        assertEquals(expected, parser.dataToPeer(peerData));
     }
 }


### PR DESCRIPTION
- Added parser interfaces for `Peer` and `Message`
- Added `SMSPeerParser`
- Added `SMSParser` as an Interface
- Added `SMSPasingManager` as an Object Pool allowing to get a parser for a certain `String` key, whose behaviour can be overridden by passing a subclass of `SMSPeerParser`.

These classes have yet to be integrated in the rest of the library: note that the default parsing performs no operations on the message.